### PR TITLE
Add ClientId support to GitHubJwtFactoryOptions

### DIFF
--- a/GitHubJwt/GitHubJwtFactory.cs
+++ b/GitHubJwt/GitHubJwtFactory.cs
@@ -29,7 +29,7 @@ namespace GitHubJwt
             {
                 {"iat", ToUtcSeconds(utcNow)},
                 {"exp", ToUtcSeconds(utcNow.AddSeconds(options.ExpirationSeconds))},
-                {"iss", options.AppIntegrationId}
+                {"iss", (object)options.ClientId ?? options.AppIntegrationId}
             };
 
             // Generate JWT

--- a/GitHubJwt/GitHubJwtFactoryOptions.cs
+++ b/GitHubJwt/GitHubJwtFactoryOptions.cs
@@ -2,6 +2,7 @@
 {
     public class GitHubJwtFactoryOptions
     {
+        public string ClientId { get; set; }
         public int AppIntegrationId { get; set; }
         public int ExpirationSeconds { get; set; }
     }


### PR DESCRIPTION
https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
> The client ID or application ID of your GitHub App. This value is used to find the right public key to verify the signature of the JWT. You can find your app's IDs on the settings page for your GitHub App. **Use of the client ID is recommended.**

(Emphasis mine)